### PR TITLE
Can I use 'j' and 'k' when select versions?

### DIFF
--- a/bin/p
+++ b/bin/p
@@ -266,8 +266,28 @@ display_versions() {
     trap handle_sigtstp SIGTSTP
 
     while true; do
-        read -n 3 c
-        case "$c" in
+        read -n 3 h
+        case "$h" in
+            k)
+            clear
+            display_versions_with_selected $(prev_version_installed)
+            continue
+            ;;
+            j)
+            clear
+            display_versions_with_selected $(next_version_installed)
+            continue
+            ;;
+            $'\033')
+            ;;
+            *)
+            activate $selected
+            leave_fullscreen
+            exit
+            ;;
+        esac
+        read -n 2 t
+        case "$h$t" in
             $UP)
             clear
             display_versions_with_selected $(prev_version_installed)


### PR DESCRIPTION
I feel inconvenient not to be able to use vim-like key bind when selecting versions and I implement it. I would be happy if you like this change.
