### PR TITLE
attempt at shellcheck warning fixes

### DIFF
--- a/bin/p
+++ b/bin/p
@@ -308,7 +308,7 @@ is_ok() {
 
 tarball_url() {
     version_directory="${version%a*}"
-    echo "${MIRROR}${version_directory%b*}/Python-${version}.tgz"
+    echo "${MIRROR[@]}" "${version_directory%b*}/Python-${version}.tgz"
 }
 
 #

--- a/bin/p
+++ b/bin/p
@@ -28,7 +28,7 @@ fi
 
 MIRROR=(${PYTHON_MIRROR-https://www.python.org/ftp/python/})
 
-test -d $BASE_VERSIONS_DIR/python || mkdir -p $BASE_VERSIONS_DIR/python
+test -d "$BASE_VERSIONS_DIR"/python || mkdir -p "$BASE_VERSIONS_DIR"/python
 
 #
 # Log <type> <msg>
@@ -43,7 +43,7 @@ log() {
 #
 
 abort() {
-    printf "\n  \033[31mError: $@\033[0m\n\n" && exit 1
+    printf "\n  \033[31mError: %s\033[0m\n\n" "$@" && exit 1
 }
 
 #
@@ -51,7 +51,7 @@ abort() {
 #
 
 success() {
-    printf "\n  \033[32mSuccess: $@\033[0m\n\n"
+    printf "\n  \033[32mSuccess: %s\033[0m\n\n" "$@"
 }
 
 #
@@ -131,11 +131,11 @@ EOF
 display_status() {
     get_current_version
 
-    log version $current
-    log bin $(display_bin_path_for_version)
-    log previous $(get_previous_version)
-    log latest $(is_latest_version)
-    log stable $(is_latest_stable_version)
+    log version "$current"
+    log bin "$(display_bin_path_for_version)"
+    log previous "$(get_previous_version)"
+    log latest "$(is_latest_version)"
+    log stable "$(is_latest_stable_version)"
 }
 
 #
@@ -159,7 +159,7 @@ show_cursor() {
 #
 
 next_version_installed() {
-    list_versions_installed | grep $selected -A 1 | tail -n 1
+    list_versions_installed | grep "$selected" -A 1 | tail -n 1
 }
 
 #
@@ -167,17 +167,17 @@ next_version_installed() {
 #
 
 prev_version_installed() {
-    list_versions_installed | grep $selected -B 1 | head -n 1
+    list_versions_installed | grep "$selected" -B 1 | head -n 1
 }
 
 #
 # Output previous version.
 #
 get_previous_version() {
-    if [ ! -f $BASE_VERSIONS_DIR/.prev ]; then
+    if [ ! -f "$BASE_VERSIONS_DIR"/.prev ]; then
         echo "none"
     else
-        echo $(cat $BASE_VERSIONS_DIR/.prev)
+        cat "$BASE_VERSIONS_DIR"/.prev
     fi
 }
 
@@ -194,7 +194,8 @@ display_p_version() {
 #
 get_current_version() {
     # current=$(python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
-    local version=$(python -V 2>&1)
+    local version
+    version=$(python -V 2>&1)
     current=${version#*Python }
 }
 
@@ -207,8 +208,8 @@ check_current_version() {
     if test $? -eq 0; then
         get_current_version
         if diff &> /dev/null \
-            $BASE_VERSIONS_DIR/python/$current/python.exe \
-            $(which python) ; then
+            "$BASE_VERSIONS_DIR"/python/"$current"/python.exe \
+            "$(which python)" ; then
             active="python/$current"
         fi
     fi
@@ -219,8 +220,8 @@ check_current_version() {
 #
 
 versions_paths() {
-    find $BASE_VERSIONS_DIR -maxdepth 2 -type d \
-        | sed 's|'$BASE_VERSIONS_DIR'/||g' \
+    find "$BASE_VERSIONS_DIR" -maxdepth 2 -type d \
+        | sed 's|'"$BASE_VERSIONS_DIR"'/||g' \
         | egrep "[0-9]+\.[0-9]+\.[0-9]+([a|b]?)([0-9]?)+" \
         | sort -k 1,1n -k 2,2n -k 3,3n -t . -k 4,4n -d -k 5,5n -r
 }
@@ -235,9 +236,9 @@ display_versions_with_selected() {
     for version in $(versions_paths); do
         version_minus_python=${version#*python\/}
         if test "$version" = "$selected"; then
-            printf "  \033[36mο\033[0m $version_minus_python\033[0m\n"
+            printf "  \033[36mο\033[0m %s\033[0m\n" "$version_minus_python"
         else
-            printf "    \033[90m$version_minus_python\033[0m\n"
+            printf "    \033[90m%s\033[0m\n" "$version_minus_python"
         fi
     done
     echo
@@ -249,7 +250,7 @@ display_versions_with_selected() {
 
 list_versions_installed() {
     for version in $(versions_paths); do
-        echo ${version}
+        echo "${version}"
     done
 }
 
@@ -260,24 +261,24 @@ list_versions_installed() {
 display_versions() {
     enter_fullscreen
     check_current_version
-    display_versions_with_selected $active
+    display_versions_with_selected "$active"
 
     trap handle_sigint INT
     trap handle_sigtstp SIGTSTP
 
     while true; do
-        read -n 3 c
+        read -r -n 3 c
         case "$c" in
             $UP)
             clear
-            display_versions_with_selected $(prev_version_installed)
+            display_versions_with_selected "$(prev_version_installed)"
             ;;
             $DOWN)
             clear
-            display_versions_with_selected $(next_version_installed)
+            display_versions_with_selected "$(next_version_installed)"
             ;;
             *)
-            activate $selected
+            activate "$selected"
             leave_fullscreen
             exit
             ;;
@@ -298,7 +299,7 @@ erase_line() {
 #
 
 is_ok() {
-    curl -Is $1 | head -n 1 | grep 200 > /dev/null
+    curl -Is "$1" | head -n 1 | grep 200 > /dev/null
 }
 
 #
@@ -318,9 +319,9 @@ activate() {
     local version=$1
     check_current_version
     if test "$version" != "$active"; then
-        echo $active > $BASE_VERSIONS_DIR/.prev
+        echo "$active" > "$BASE_VERSIONS_DIR"/.prev
 
-        ln -sf $BASE_VERSIONS_DIR/$version/python.exe $BASE_VERSIONS_DIR/python/python
+        ln -sf "$BASE_VERSIONS_DIR"/"$version"/python.exe "$BASE_VERSIONS_DIR"/python/python
     fi
 }
 
@@ -329,13 +330,14 @@ activate() {
 #
 
 activate_previous() {
-    test -f $BASE_VERSIONS_DIR/.prev || abort "no previous versions activated"
-    local prev=$(cat $BASE_VERSIONS_DIR/.prev)
-    test -d $BASE_VERSIONS_DIR/$prev || abort "previous version $prev not installed"
-    activate $prev
+    test -f "$BASE_VERSIONS_DIR"/.prev || abort "no previous versions activated"
+    local prev
+    prev=$(cat "$BASE_VERSIONS_DIR"/.prev)
+    test -d "$BASE_VERSIONS_DIR"/"$prev" || abort "previous version $prev not installed"
+    activate "$prev"
     echo
     get_current_version
-    log activate $current
+    log activate "$current"
     echo
 
     success "Now using Python $current!"
@@ -347,7 +349,7 @@ activate_previous() {
 activate_default() {
     log activate default
 
-    rm -rf $BASE_VERSIONS_DIR/python/python
+    rm -rf "$BASE_VERSIONS_DIR"/python/python
 
     get_current_version
     success "Now using Python $current!\n  Use \`p <version>\` to activate another version."
@@ -360,27 +362,29 @@ activate_default() {
 install() {
     local version=${1#v}
 
-    local dots=$(echo $version | sed 's/[^.]*//g')
+    local dots
+    dots=$(echo "$version" | sed 's/[^.]*//g')
     if test ${#dots} -eq 1; then
-        version=$($GET 2> /dev/null ${MIRROR} \
+        version=$($GET 2> /dev/null "${MIRROR[@]}" \
             | egrep -o '[0-9]+\.[0-9]+\.[0-9]+' \
             | egrep -v '^0\.[0-7]\.' \
             | egrep -v '^0\.8\.[0-5]$' \
             | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
-            | egrep ^$version \
+            | egrep ^"$version" \
             | tail -n1)
 
-        test $version || abort "invalid version ${1#v}"
+        test "$version" || abort "invalid version ${1#v}"
     fi
 
     local dir=$BASE_VERSIONS_DIR/python/$version
-    local url=$(tarball_url $version)
+    local url
+    url=$(tarball_url "$version")
 
-    if test -d $dir; then
-        if [[ ! -e $dir/n.lock ]] ; then
-            activate python/$version
+    if test -d "$dir"; then
+        if [[ ! -e "$dir"/n.lock ]] ; then
+            activate python/"$version"
 
-            log activate $version
+            log activate "$version"
 
             get_current_version
             success "Now using Python $current!"
@@ -390,39 +394,39 @@ install() {
     fi
 
     echo
-    log install Python-$version
+    log install Python-"$version"
 
-    is_ok $url || abort "invalid version $version"
+    is_ok "$url" || abort "invalid version $version"
 
-    log create $dir
-    mkdir -p $dir
+    log create "$dir"
+    mkdir -p "$dir"
     if [ $? -ne 0 ] ; then
         abort "sudo required"
     else
-        touch $dir/p.lock
+        touch "$dir"/p.lock
     fi
 
-    cd $dir
+    cd "$dir" || exit
 
-    log fetch $url
+    log fetch "$url"
 
-    curl -L# $url | tar -zx --strip 1
+    curl -L# "$url" | tar -zx --strip 1
 
     erase_line
-    rm -f $dir/p.lock
+    rm -f "$dir"/p.lock
 
-    log configure $version
+    log configure "$version"
     ./configure &> /dev/null
 
-    log compile $version
+    log compile "$version"
     make &> /dev/null
 
     if [ ! -f "python.exe" ]; then
     	abort "Unable to compile Python $version!"
     fi
 
-    activate python/$version
-    log activate $version
+    activate python/"$version"
+    log activate "$version"
 
     log refresh \$PATH
     export PATH=/usr/local/p/versions/python:$PATH
@@ -442,7 +446,7 @@ install() {
 #
 
 remove_versions() {
-    test -z $1 && abort "version(s) required"
+    test -z "$1" && abort "version(s) required"
 
     for version in "$@"; do
         if [[ "$version" = "latest" ]]; then
@@ -451,11 +455,11 @@ remove_versions() {
             version=$(display_latest_stable_version)
         fi
 
-        rm -rf $BASE_VERSIONS_DIR/python/${version#v}
-        log remove $version
+        rm -rf "$BASE_VERSIONS_DIR"/python/"${version#v}"
+        log remove "$version"
     done
 
-    versions=$@
+    versions=("$@")
 
     success "Removed Python ${versions// /, }!"
 }
@@ -467,10 +471,10 @@ remove_versions() {
 display_bin_path_for_version() {
     get_current_version
 
-    if [ ! -z $1 ]; then
+    if [ ! -z "$1" ]; then
         local version=${1#v}
     else
-        if [ ! -d $BASE_VERSIONS_DIR/python/$current ]; then
+        if [ ! -d "$BASE_VERSIONS_DIR"/python/"$current" ]; then
             abort "Version required!"
         else
             local version=$current;
@@ -478,8 +482,8 @@ display_bin_path_for_version() {
     fi
 
     local bin=$BASE_VERSIONS_DIR/python/$version/python.exe
-    if test -f $bin; then
-        printf "$bin \n"
+    if test -f "$bin"; then
+        printf "%s \n" "$bin"
     else
         abort "Python $version is not installed"
     fi
@@ -490,7 +494,7 @@ display_bin_path_for_version() {
 #
 
 execute_with_version() {
-    test -z $1 && abort "version required"
+    test -z "$1" && abort "version required"
     local version=${1#v}
 
     if [[ "$version" = "latest" ]]; then
@@ -503,7 +507,7 @@ execute_with_version() {
 
     shift # remove version
 
-    if test -f $bin; then
+    if test -f "$bin"; then
         $bin "$@"
     else
         abort "Python $version is not installed"
@@ -515,12 +519,12 @@ execute_with_version() {
 #
 
 display_latest_version() {
-    latest_directory=$($GET 2> /dev/null ${MIRROR} \
+    latest_directory=$($GET 2> /dev/null "${MIRROR[@]}" \
         | egrep -o '[0-9]+\.[0-9]+\.[0-9]+' \
         | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
         | tail -n1)
 
-    $GET 2> /dev/null ${MIRROR}$latest_directory \
+    $GET 2> /dev/null "${MIRROR[@]}" "$latest_directory" \
         | egrep -o '[0-9]+\.[0-9]+\.[0-9]+[a|b][0-9]+' \
         | sort -k 1,1n -k 2,2n -k 3,3n -t . -k 4,4n -d -k 5,5n -d \
         | tail -n1
@@ -544,7 +548,7 @@ is_latest_version() {
 #
 
 display_latest_stable_version() {
-    $GET 2> /dev/null ${MIRROR} \
+    $GET 2> /dev/null "${MIRROR[@]}" \
         | egrep -o '[0-9]+\.[0-9]*[02468]\.[0-9]+' \
         | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
         | tail -n1
@@ -570,7 +574,7 @@ is_latest_stable_version() {
 display_remote_versions() {
     check_current_version
     local versions=""
-    versions=$($GET 2> /dev/null ${MIRROR} \
+    versions=$($GET 2> /dev/null "${MIRROR[@]}" \
     | egrep -o '[0-9]+\.[0-9]+\.[0-9]+' \
     | egrep -v '^0\.[0-7]\.' \
     | egrep -v '^0\.8\.[0-5]$' \
@@ -581,12 +585,12 @@ display_remote_versions() {
 
     for v in $versions; do
         if test "$active" = "python/$v"; then
-            printf "  \033[36mο\033[0m $v \033[0m\n"
+            printf "  \033[36mο\033[0m %s \033[0m\n" "$v"
         else
-            if test -d $BASE_VERSIONS_DIR/python/$v; then
-                printf "    $v \033[0m\n"
+            if test -d "$BASE_VERSIONS_DIR"/python/"$v"; then
+                printf "    %s \033[0m\n" "$v"
             else
-                printf "    \033[90m$v\033[0m\n"
+                printf "    \033[90m%s\033[0m\n" "$v"
             fi
         fi
     done
@@ -608,13 +612,13 @@ else
             status) display_status ;;
             bin|which)
             case $2 in
-                latest) display_bin_path_for_version $($0 ls latest); exit ;;
-                stable) display_bin_path_for_version $($0 ls stable); exit ;;
-                *) display_bin_path_for_version $2; exit ;;
+                latest) display_bin_path_for_version "$($0 ls latest)"; exit ;;
+                stable) display_bin_path_for_version "$($0 ls stable)"; exit ;;
+                *) display_bin_path_for_version "$2"; exit ;;
             esac
             exit ;;
-            as|use) shift; execute_with_version $@; exit ;;
-            rm|-) shift; remove_versions $@; exit ;;
+            as|use) shift; execute_with_version "$@"; exit ;;
+            rm|-) shift; remove_versions "$@"; exit ;;
             ls|list)
             case $2 in
                 latest) display_latest_version; exit ;;
@@ -624,9 +628,9 @@ else
             exit ;;
             prev|previous) activate_previous; exit ;;
             default) activate_default; exit ;;
-            latest) install $($0 ls latest); exit ;;
-            stable) install $($0 ls stable); exit ;;
-            *) install $1; exit ;;
+            latest) install "$($0 ls latest)"; exit ;;
+            stable) install "$($0 ls stable)"; exit ;;
+            *) install "$1"; exit ;;
         esac
         shift
     done


### PR DESCRIPTION
This is for #1 

Currently the only errors being displayed from shellcheck is:

↘ shellcheck p

In p line 311:
    echo "${MIRROR}${version_directory%b*}/Python-${version}.tgz"
          ^-- SC2128: Expanding an array without an index only gives the first element.


In p line 366:
    dots=$(echo "$version" | sed 's/[^.]*//g')
           ^-- SC2001: See if you can use ${variable//search/replace} instead.


In p line 434:
    source ~/.bashrc
    ^-- SC1091: Not following: ~/.bashrc was not specified as input (see shellcheck -x).


In p line 435:
    source ~/.zshrc
    ^-- SC1091: Not following: ~/.zshrc was not specified as input (see shellcheck -x).


Nothing is broken at first glance for me, but not to say it's perfect.